### PR TITLE
Parse email with just a binary attachment and no text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/DusanKasan/parsemail
+module github.com/get-net/parsemail
 
 go 1.12

--- a/parsemail.go
+++ b/parsemail.go
@@ -18,6 +18,7 @@ const contentTypeMultipartAlternative = "multipart/alternative"
 const contentTypeMultipartRelated = "multipart/related"
 const contentTypeTextHtml = "text/html"
 const contentTypeTextPlain = "text/plain"
+const contentTypeOctetStream = "application/octet-stream"
 
 // Parse an email message read from io.Reader into parsemail.Email struct
 func Parse(r io.Reader) (email Email, err error) {
@@ -50,6 +51,8 @@ func Parse(r io.Reader) (email Email, err error) {
 	case contentTypeTextHtml:
 		message, _ := ioutil.ReadAll(msg.Body)
 		email.HTMLBody = strings.TrimSuffix(string(message[:]), "\n")
+	case contentTypeOctetStream:
+		email.Attachments, err = parseAttachmentOnlyEmail(msg.Body, msg.Header)
 	default:
 		email.Content, err = decodeContent(msg.Body, msg.Header.Get("Content-Transfer-Encoding"))
 	}
@@ -101,6 +104,29 @@ func parseContentType(contentTypeHeader string) (contentType string, params map[
 	}
 
 	return mime.ParseMediaType(contentTypeHeader)
+}
+
+func parseAttachmentOnlyEmail(body io.Reader, header mail.Header) (attachments []Attachment, err error) {
+	attachmentData, err := decodeContent(body, header.Get("Content-Transfer-Encoding"))
+	contentDisposition := header.Get("Content-Disposition")
+
+	if err != nil {
+		return attachments, err
+	}
+
+	if len(contentDisposition) > 0 && strings.Contains(contentDisposition, "attachment;") {
+		fileName := strings.Replace(contentDisposition, "attachment; filename=\"", "", -1)
+		fileName = strings.TrimRight(fileName, "\"")
+
+		at := Attachment{
+			Filename:    fileName,
+			ContentType: "application/octet-stream",
+			Data:        attachmentData,
+		}
+		attachments = append(attachments, at)
+	}
+
+	return attachments, nil
 }
 
 func parseMultipartRelated(msg io.Reader, boundary string) (textBody, htmlBody string, embeddedFiles []EmbeddedFile, err error) {
@@ -483,7 +509,7 @@ type Email struct {
 	ResentMessageID string
 
 	ContentType string
-	Content io.Reader
+	Content     io.Reader
 
 	HTMLBody string
 	TextBody string

--- a/parsemail.go
+++ b/parsemail.go
@@ -107,14 +107,15 @@ func parseContentType(contentTypeHeader string) (contentType string, params map[
 }
 
 func parseAttachmentOnlyEmail(body io.Reader, header mail.Header) (attachments []Attachment, err error) {
-	attachmentData, err := decodeContent(body, header.Get("Content-Transfer-Encoding"))
 	contentDisposition := header.Get("Content-Disposition")
 
-	if err != nil {
-		return attachments, err
-	}
-
 	if len(contentDisposition) > 0 && strings.Contains(contentDisposition, "attachment;") {
+
+		attachmentData, err := decodeContent(body, header.Get("Content-Transfer-Encoding"))
+		if err != nil {
+			return attachments, err
+		}
+
 		fileName := strings.Replace(contentDisposition, "attachment; filename=\"", "", -1)
 		fileName = strings.TrimRight(fileName, "\"")
 
@@ -123,6 +124,7 @@ func parseAttachmentOnlyEmail(body io.Reader, header mail.Header) (attachments [
 			ContentType: "application/octet-stream",
 			Data:        attachmentData,
 		}
+
 		attachments = append(attachments, at)
 	}
 


### PR DESCRIPTION
There are emails with no text in the body that contain only a binary attachment. Mail clients handle those as proper attachments yet parsemail doesn't recognize them.